### PR TITLE
Removing manuela-ml-workspace from excludes list for Operator Group

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -14,7 +14,6 @@ clusterGroup:
   - vault
 
   operatorgroupExcludes:
-  - manuela-ml-workspace
 
   subscriptions:
     acm:


### PR DESCRIPTION
- Removing manuela-ml-workspace from excludes list for Operator Group
