### PR TITLE
Ensure built_tags is handled as an array with blank values file

### DIFF
--- a/charts/datacenter/manuela-tst/templates/messaging/messaging-is.yaml
+++ b/charts/datacenter/manuela-tst/templates/messaging/messaging-is.yaml
@@ -11,7 +11,7 @@ spec:
     importPolicy: {}
     referencePolicy:
       type: Local
-{{- if .Values.iot_consumer.built_tags }}
+{{- range .Values.iot_consumer.built_tags }}
   - name: {{ . | quote }}
     from:
       kind: DockerImage

--- a/charts/datacenter/pipelines/templates/tasks/gitops-imagetag.yaml
+++ b/charts/datacenter/pipelines/templates/tasks/gitops-imagetag.yaml
@@ -47,7 +47,7 @@ spec:
       ls -al $VALUES_PATH
       BUILT_TAGS_PATH="$(cat $(workspaces.config.path)/$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH)"
       echo "$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH) : $BUILT_TAGS_PATH"
-      yq "$BUILT_TAGS_PATH += \"$TAG_VALUE\"" $VALUES_PATH > $VALUES_PATH.tmp
+      yq "$BUILT_TAGS_PATH += [ \"$TAG_VALUE\" ]" $VALUES_PATH > $VALUES_PATH.tmp
       mv $VALUES_PATH.tmp $VALUES_PATH
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: prune-built-tags

--- a/charts/factory/manuela-stormshift/templates/messaging/messaging-is.yaml
+++ b/charts/factory/manuela-stormshift/templates/messaging/messaging-is.yaml
@@ -14,7 +14,7 @@ spec:
     importPolicy: {}
     referencePolicy:
       type: Local
-{{- if .Values.iot_consumer.built_tags }}
+{{- range .Values.iot_consumer.built_tags }}
   - name: {{ $.Values.iot_consumer.tag | quote }}
     from:
       kind: DockerImage

--- a/tests/datacenter-pipelines-industrial-edge-factory.expected.yaml
+++ b/tests/datacenter-pipelines-industrial-edge-factory.expected.yaml
@@ -3539,7 +3539,7 @@ spec:
       ls -al $VALUES_PATH
       BUILT_TAGS_PATH="$(cat $(workspaces.config.path)/$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH)"
       echo "$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH) : $BUILT_TAGS_PATH"
-      yq "$BUILT_TAGS_PATH += \"$TAG_VALUE\"" $VALUES_PATH > $VALUES_PATH.tmp
+      yq "$BUILT_TAGS_PATH += [ \"$TAG_VALUE\" ]" $VALUES_PATH > $VALUES_PATH.tmp
       mv $VALUES_PATH.tmp $VALUES_PATH
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: prune-built-tags

--- a/tests/datacenter-pipelines-industrial-edge-hub.expected.yaml
+++ b/tests/datacenter-pipelines-industrial-edge-hub.expected.yaml
@@ -3539,7 +3539,7 @@ spec:
       ls -al $VALUES_PATH
       BUILT_TAGS_PATH="$(cat $(workspaces.config.path)/$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH)"
       echo "$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH) : $BUILT_TAGS_PATH"
-      yq "$BUILT_TAGS_PATH += \"$TAG_VALUE\"" $VALUES_PATH > $VALUES_PATH.tmp
+      yq "$BUILT_TAGS_PATH += [ \"$TAG_VALUE\" ]" $VALUES_PATH > $VALUES_PATH.tmp
       mv $VALUES_PATH.tmp $VALUES_PATH
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: prune-built-tags

--- a/tests/datacenter-pipelines-medical-diagnosis-hub.expected.yaml
+++ b/tests/datacenter-pipelines-medical-diagnosis-hub.expected.yaml
@@ -3539,7 +3539,7 @@ spec:
       ls -al $VALUES_PATH
       BUILT_TAGS_PATH="$(cat $(workspaces.config.path)/$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH)"
       echo "$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH) : $BUILT_TAGS_PATH"
-      yq "$BUILT_TAGS_PATH += \"$TAG_VALUE\"" $VALUES_PATH > $VALUES_PATH.tmp
+      yq "$BUILT_TAGS_PATH += [ \"$TAG_VALUE\" ]" $VALUES_PATH > $VALUES_PATH.tmp
       mv $VALUES_PATH.tmp $VALUES_PATH
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: prune-built-tags

--- a/tests/datacenter-pipelines-naked.expected.yaml
+++ b/tests/datacenter-pipelines-naked.expected.yaml
@@ -3539,7 +3539,7 @@ spec:
       ls -al $VALUES_PATH
       BUILT_TAGS_PATH="$(cat $(workspaces.config.path)/$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH)"
       echo "$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH) : $BUILT_TAGS_PATH"
-      yq "$BUILT_TAGS_PATH += \"$TAG_VALUE\"" $VALUES_PATH > $VALUES_PATH.tmp
+      yq "$BUILT_TAGS_PATH += [ \"$TAG_VALUE\" ]" $VALUES_PATH > $VALUES_PATH.tmp
       mv $VALUES_PATH.tmp $VALUES_PATH
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: prune-built-tags

--- a/tests/datacenter-pipelines-normal.expected.yaml
+++ b/tests/datacenter-pipelines-normal.expected.yaml
@@ -3539,7 +3539,7 @@ spec:
       ls -al $VALUES_PATH
       BUILT_TAGS_PATH="$(cat $(workspaces.config.path)/$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH)"
       echo "$(params.CONFIGMAP_PREFIX)_BUILT_TAGS_PATH) : $BUILT_TAGS_PATH"
-      yq "$BUILT_TAGS_PATH += \"$TAG_VALUE\"" $VALUES_PATH > $VALUES_PATH.tmp
+      yq "$BUILT_TAGS_PATH += [ \"$TAG_VALUE\" ]" $VALUES_PATH > $VALUES_PATH.tmp
       mv $VALUES_PATH.tmp $VALUES_PATH
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: prune-built-tags


### PR DESCRIPTION
Add `[]` to `yq` call to ensure that built_tags is treated as an array, even if the override values file is empty. This fixes an issue where running `make seed` would break the deployment; the Helm chart fails if built_tags is a string rather than an array.