### PR TITLE
Fix missing images

### DIFF
--- a/charts/datacenter/pipelines/images/bumpversiontask/README.md
+++ b/charts/datacenter/pipelines/images/bumpversiontask/README.md
@@ -1,4 +1,4 @@
 # bumpversiontask
 
 Create a container image that can be used as Tekton task to bump a version using bump2version.
-Image is build using quay, you can find the consumable image [here](https://quay.io/repository/manuela/bumpversiontask?tab=tags)
+Image is build using quay, you can find the consumable image [here](https://quay.io/repository/hybridcloudpatterns/bumpversiontask?tab=tags)

--- a/charts/datacenter/pipelines/templates/pipelines/build-iot-frontend.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-iot-frontend.yaml
@@ -79,7 +79,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE

--- a/charts/datacenter/pipelines/templates/pipelines/seed-iot-frontend.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/seed-iot-frontend.yaml
@@ -79,7 +79,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE

--- a/charts/datacenter/pipelines/templates/tasks/bumpversion.yaml
+++ b/charts/datacenter/pipelines/templates/tasks/bumpversion.yaml
@@ -47,7 +47,7 @@ spec:
       name: scratch
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: bump-tag
-    image: quay.io/manuela/bumpversiontask:latest
+    image: quay.io/hybridcloudpatterns/bumpversiontask:latest
     script: |
       cd /scratch
       echo -e "[bumpversion]\ncurrent_version = $(cat VERSION)" >.bumpversion.cfg

--- a/charts/datacenter/pipelines/templates/templates/build-iot-frontend.yaml
+++ b/charts/datacenter/pipelines/templates/templates/build-iot-frontend.yaml
@@ -50,4 +50,4 @@ objects:
       value: IOT_FRONTEND
     - name: CHAINED_BUILD_DOCKERFILE
       #value: "FROM centos/httpd-24-centos7\nCOPY --from=0 /opt/app-root/output /var/www/html/"
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"

--- a/tests/datacenter-pipelines-industrial-edge-factory.expected.yaml
+++ b/tests/datacenter-pipelines-industrial-edge-factory.expected.yaml
@@ -1400,7 +1400,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -2342,7 +2342,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3094,7 +3094,7 @@ spec:
       name: scratch
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: bump-tag
-    image: quay.io/manuela/bumpversiontask:latest
+    image: quay.io/hybridcloudpatterns/bumpversiontask:latest
     script: |
       cd /scratch
       echo -e "[bumpversion]\ncurrent_version = $(cat VERSION)" >.bumpversion.cfg
@@ -4063,7 +4063,7 @@ objects:
       value: IOT_FRONTEND
     - name: CHAINED_BUILD_DOCKERFILE
       #value: "FROM centos/httpd-24-centos7\nCOPY --from=0 /opt/app-root/output /var/www/html/"
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
 ---
 # Source: pipelines/templates/templates/build-iot-software-sensor-quarkus.yaml
 apiVersion: template.openshift.io/v1

--- a/tests/datacenter-pipelines-industrial-edge-hub.expected.yaml
+++ b/tests/datacenter-pipelines-industrial-edge-hub.expected.yaml
@@ -1400,7 +1400,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -2342,7 +2342,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3094,7 +3094,7 @@ spec:
       name: scratch
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: bump-tag
-    image: quay.io/manuela/bumpversiontask:latest
+    image: quay.io/hybridcloudpatterns/bumpversiontask:latest
     script: |
       cd /scratch
       echo -e "[bumpversion]\ncurrent_version = $(cat VERSION)" >.bumpversion.cfg
@@ -4063,7 +4063,7 @@ objects:
       value: IOT_FRONTEND
     - name: CHAINED_BUILD_DOCKERFILE
       #value: "FROM centos/httpd-24-centos7\nCOPY --from=0 /opt/app-root/output /var/www/html/"
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
 ---
 # Source: pipelines/templates/templates/build-iot-software-sensor-quarkus.yaml
 apiVersion: template.openshift.io/v1

--- a/tests/datacenter-pipelines-medical-diagnosis-hub.expected.yaml
+++ b/tests/datacenter-pipelines-medical-diagnosis-hub.expected.yaml
@@ -1400,7 +1400,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -2342,7 +2342,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3094,7 +3094,7 @@ spec:
       name: scratch
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: bump-tag
-    image: quay.io/manuela/bumpversiontask:latest
+    image: quay.io/hybridcloudpatterns/bumpversiontask:latest
     script: |
       cd /scratch
       echo -e "[bumpversion]\ncurrent_version = $(cat VERSION)" >.bumpversion.cfg
@@ -4063,7 +4063,7 @@ objects:
       value: IOT_FRONTEND
     - name: CHAINED_BUILD_DOCKERFILE
       #value: "FROM centos/httpd-24-centos7\nCOPY --from=0 /opt/app-root/output /var/www/html/"
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
 ---
 # Source: pipelines/templates/templates/build-iot-software-sensor-quarkus.yaml
 apiVersion: template.openshift.io/v1

--- a/tests/datacenter-pipelines-naked.expected.yaml
+++ b/tests/datacenter-pipelines-naked.expected.yaml
@@ -1400,7 +1400,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -2342,7 +2342,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3094,7 +3094,7 @@ spec:
       name: scratch
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: bump-tag
-    image: quay.io/manuela/bumpversiontask:latest
+    image: quay.io/hybridcloudpatterns/bumpversiontask:latest
     script: |
       cd /scratch
       echo -e "[bumpversion]\ncurrent_version = $(cat VERSION)" >.bumpversion.cfg
@@ -4063,7 +4063,7 @@ objects:
       value: IOT_FRONTEND
     - name: CHAINED_BUILD_DOCKERFILE
       #value: "FROM centos/httpd-24-centos7\nCOPY --from=0 /opt/app-root/output /var/www/html/"
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
 ---
 # Source: pipelines/templates/templates/build-iot-software-sensor-quarkus.yaml
 apiVersion: template.openshift.io/v1

--- a/tests/datacenter-pipelines-normal.expected.yaml
+++ b/tests/datacenter-pipelines-normal.expected.yaml
@@ -1400,7 +1400,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -2342,7 +2342,7 @@ spec:
     - name: BUILDER_IMAGE
       value: nodeshift/ubi8-s2i-web-app
     - name: CHAINED_BUILD_DOCKERFILE
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
     - name: TAG
       value: $(tasks.bump-build-version-iot-frontend.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3094,7 +3094,7 @@ spec:
       name: scratch
     workingDir: $(workspaces.gitrepos.path)/$(params.subdirectory)
   - name: bump-tag
-    image: quay.io/manuela/bumpversiontask:latest
+    image: quay.io/hybridcloudpatterns/bumpversiontask:latest
     script: |
       cd /scratch
       echo -e "[bumpversion]\ncurrent_version = $(cat VERSION)" >.bumpversion.cfg
@@ -4063,7 +4063,7 @@ objects:
       value: IOT_FRONTEND
     - name: CHAINED_BUILD_DOCKERFILE
       #value: "FROM centos/httpd-24-centos7\nCOPY --from=0 /opt/app-root/output /var/www/html/"
-      value: "FROM quay.io/manuela/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
+      value: "FROM quay.io/hybridcloudpatterns/httpd-ionic\nCOPY --from=0 /opt/app-root/output /var/www/html/"
 ---
 # Source: pipelines/templates/templates/build-iot-software-sensor-quarkus.yaml
 apiVersion: template.openshift.io/v1


### PR DESCRIPTION
When running `./pattern.sh make seed` pipelines started failing with:

 message: >-
        The step "bump-tag" in TaskRun
        "seed-iot-software-sensor-run-nlc337daeaf685c4f96b31e380c986de26" failed
        to pull the image "". The pod errored with the message: "Back-off
        pulling image "quay.io/manuela/bumpversiontask:latest"."

Seems the `latest` tag has gone missing on both the bumpversiontask
image and the httpd-ionic image under the manuela org.

Let's just use the images in our hybridcloudpatterns org.

Tested and now make seed is able to build the tasks seed-iot-frontend,
seed-iot-consumer and seed-iot-anomaly-detection correctly again.

Reported-by: Wolfgang Huse <wolfgang.huse@nutanix.com>
