### PR TITLE
Use a more recent image for python

### DIFF
--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
@@ -85,7 +85,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE

--- a/charts/datacenter/pipelines/templates/pipelines/build-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-iot-anomaly-detection.yaml
@@ -77,7 +77,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE

--- a/charts/datacenter/pipelines/templates/pipelines/seed-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/seed-iot-anomaly-detection.yaml
@@ -77,7 +77,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE

--- a/charts/datacenter/pipelines/templates/templates/build-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/templates/build-iot-anomaly-detection.yaml
@@ -39,7 +39,7 @@ objects:
               storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: LOCAL_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
     - name: PATH_CONTEXT

--- a/tests/datacenter-pipelines-industrial-edge-factory.expected.yaml
+++ b/tests/datacenter-pipelines-industrial-edge-factory.expected.yaml
@@ -186,7 +186,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1077,7 +1077,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1979,7 +1979,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3948,7 +3948,7 @@ objects:
               storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: LOCAL_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
     - name: PATH_CONTEXT

--- a/tests/datacenter-pipelines-industrial-edge-hub.expected.yaml
+++ b/tests/datacenter-pipelines-industrial-edge-hub.expected.yaml
@@ -186,7 +186,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1077,7 +1077,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1979,7 +1979,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3948,7 +3948,7 @@ objects:
               storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: LOCAL_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
     - name: PATH_CONTEXT

--- a/tests/datacenter-pipelines-medical-diagnosis-hub.expected.yaml
+++ b/tests/datacenter-pipelines-medical-diagnosis-hub.expected.yaml
@@ -186,7 +186,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1077,7 +1077,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1979,7 +1979,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3948,7 +3948,7 @@ objects:
               storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: LOCAL_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
     - name: PATH_CONTEXT

--- a/tests/datacenter-pipelines-naked.expected.yaml
+++ b/tests/datacenter-pipelines-naked.expected.yaml
@@ -186,7 +186,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1077,7 +1077,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1979,7 +1979,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3948,7 +3948,7 @@ objects:
               storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: LOCAL_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
     - name: PATH_CONTEXT

--- a/tests/datacenter-pipelines-normal.expected.yaml
+++ b/tests/datacenter-pipelines-normal.expected.yaml
@@ -186,7 +186,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1077,7 +1077,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -1979,7 +1979,7 @@ spec:
     - name: PATH_CONTEXT
       value: components/iot-anomaly-detection
     - name: BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: TAG
       value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
     - name: OUTPUT_IMAGE
@@ -3948,7 +3948,7 @@ objects:
               storage: 128Mi
     params:
     - name: S2I_BUILDER_IMAGE
-      value: registry.access.redhat.com/rhscl/python-36-rhel7
+      value: quay.io/hybridcloudpatterns/python-38-rhel7
     - name: LOCAL_IMAGE
       value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
     - name: PATH_CONTEXT


### PR DESCRIPTION
The current one bails with:
```
STEP 2: LABEL "io.openshift.s2i.build.image"="registry.access.redhat.com/rhscl/python-36-rhel7"       "io.openshift.s2i.build.source-
...
STEP 9: RUN /usr/libexec/s2i/assemble
---> Installing application source ...
---> Upgrading pip to version 19.3.1 ...
Collecting pip==19.3.1
  Could not fetch URL https://pypi.python.org/simple/pip/: There was a problem confirming the ssl certificate: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852) - skipping
```

Use a more recent one that works correctly.
