### PR TITLE
Add check for external test to skip operator version check

### DIFF
--- a/tests/interop/test_subscription_status_hub.py
+++ b/tests/interop/test_subscription_status_hub.py
@@ -76,7 +76,9 @@ def test_subscription_status_hub(openshift_dyn_client):
         except Exception:
             pass
 
-        previouspath = os.getcwd() + f"/operator-versions/industrialedge_hub_{shortversion}"
+        previouspath = (
+            os.getcwd() + f"/operator-versions/industrialedge_hub_{shortversion}"
+        )
         previousfile = f"industrialedge_hub_{shortversion}"
 
         logger.info("Ensure previous file exists")

--- a/tests/interop/test_subscription_status_hub.py
+++ b/tests/interop/test_subscription_status_hub.py
@@ -53,47 +53,48 @@ def test_subscription_status_hub(openshift_dyn_client):
 
     cluster_version = subscription.openshift_version(openshift_dyn_client)
     logger.info(f"Openshift version:\n{cluster_version.instance.status.history}")
-    shortversion = re.sub("(.[0-9]+$)", "", os.getenv("OPENSHIFT_VER"))
 
-    currentfile = os.getcwd() + "/operators_hub_current"
-    sourceFile = open(currentfile, "w")
-    for line in operator_versions:
-        logger.info(line)
-        print(line, file=sourceFile)
-    sourceFile.close()
-
-    logger.info("Clone operator-versions repo")
-    try:
-        operator_versions_repo = (
-            "git@gitlab.cee.redhat.com:mpqe/mps/vp/operator-versions.git"
-        )
-        clone = subprocess.run(
-            ["git", "clone", operator_versions_repo], capture_output=True, text=True
-        )
-        logger.info(clone.stdout)
-        logger.info(clone.stderr)
-    except Exception:
-        pass
-
-    previouspath = os.getcwd() + f"/operator-versions/manuela_hub_{shortversion}"
-    previousfile = f"manuela_hub_{shortversion}"
-
-    logger.info("Ensure previous file exists")
-    checkpath = os.path.exists(previouspath)
-    logger.info(checkpath)
-
-    if checkpath is True:
-        logger.info("Diff current operator list with previous file")
-        diff = opdiff(open(previouspath).readlines(), open(currentfile).readlines())
-        diffstring = "".join(diff)
-        logger.info(diffstring)
-
-        logger.info("Write diff to file")
-        sourceFile = open("operator_diffs_hub.log", "w")
-        print(diffstring, file=sourceFile)
+    if os.getenv("EXTERNAL_TEST") != "true":
+        shortversion = re.sub("(.[0-9]+$)", "", os.getenv("OPENSHIFT_VER"))
+        currentfile = os.getcwd() + "/operators_hub_current"
+        sourceFile = open(currentfile, "w")
+        for line in operator_versions:
+            logger.info(line)
+            print(line, file=sourceFile)
         sourceFile.close()
-    else:
-        logger.info("Skipping operator diff - previous file not found")
+
+        logger.info("Clone operator-versions repo")
+        try:
+            operator_versions_repo = (
+                "git@gitlab.cee.redhat.com:mpqe/mps/vp/operator-versions.git"
+            )
+            clone = subprocess.run(
+                ["git", "clone", operator_versions_repo], capture_output=True, text=True
+            )
+            logger.info(clone.stdout)
+            logger.info(clone.stderr)
+        except Exception:
+            pass
+
+        previouspath = os.getcwd() + f"/operator-versions/industrialedge_hub_{shortversion}"
+        previousfile = f"industrialedge_hub_{shortversion}"
+
+        logger.info("Ensure previous file exists")
+        checkpath = os.path.exists(previouspath)
+        logger.info(checkpath)
+
+        if checkpath is True:
+            logger.info("Diff current operator list with previous file")
+            diff = opdiff(open(previouspath).readlines(), open(currentfile).readlines())
+            diffstring = "".join(diff)
+            logger.info(diffstring)
+
+            logger.info("Write diff to file")
+            sourceFile = open("operator_diffs_hub.log", "w")
+            print(diffstring, file=sourceFile)
+            sourceFile.close()
+        else:
+            logger.info("Skipping operator diff - previous file not found")
 
     if missing_subs or unhealthy_subs or missing_installplans or upgrades_pending:
         err_msg = "Subscription status check failed"
@@ -101,20 +102,23 @@ def test_subscription_status_hub(openshift_dyn_client):
         assert False, err_msg
     else:
         # Only push the new operarator list if the test passed
-        if checkpath is True:
-            os.remove(previouspath)
-            os.rename(currentfile, previouspath)
+        # and we are not testing a pre-release operator nor
+        # running externally
+        if os.getenv("EXTERNAL_TEST") != "true":
+            if checkpath is True and not os.environ["INDEX_IMAGE"]:
+                os.remove(previouspath)
+                os.rename(currentfile, previouspath)
 
-            cwd = os.getcwd() + "/operator-versions"
-            logger.info(f"CWD: {cwd}")
+                cwd = os.getcwd() + "/operator-versions"
+                logger.info(f"CWD: {cwd}")
 
-            logger.info("Push new operator list")
-            subprocess.run(["git", "add", previousfile], cwd=cwd)
-            subprocess.run(
-                ["git", "commit", "-m", "Update operator versions list"],
-                cwd=cwd,
-            )
-            subprocess.run(["git", "push"], cwd=cwd)
+                logger.info("Push new operator list")
+                subprocess.run(["git", "add", previousfile], cwd=cwd)
+                subprocess.run(
+                    ["git", "commit", "-m", "Update operator versions list"],
+                    cwd=cwd,
+                )
+                subprocess.run(["git", "push"], cwd=cwd)
 
         logger.info("PASS: Subscription status check passed")
 


### PR DESCRIPTION
The operator version check should be skipped when running CI outside of our pipeline.