### PR TITLE
Revert "Drop double manuela-ci namespace"

### DIFF
--- a/charts/secrets/pipeline-setup/templates/namespace.yaml
+++ b/charts/secrets/pipeline-setup/templates/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: manuela-ci
+  labels:
+    manuela-role: pipeline
+    app.kubernetes.io/instance: manuela
+      #argocd.argoproj.io/managed-by: openshift-gitops
+spec:
+  finalizers:
+  - kubernetes

--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -12,9 +12,7 @@ clusterGroup:
   - open-cluster-management
   - manuela-ml-workspace
   - manuela-tst-all
-  - manuela-ci:
-      labels:
-        manuela-role: pipeline
+  - manuela-ci
   - manuela-data-lake
   - staging
   - vault


### PR DESCRIPTION
This reverts commit 2568e0ccd83ac02280e7356f748051f4545b5b5c.

manuela-ci namespace is needed by the pipeline-setup target. Until we
figure that out properly let's revert this.
