### PR TITLE
Switch to traits for kafka integrations

### DIFF
--- a/charts/datacenter/manuela-data-lake/templates/central-s3-store/kafka-to-s3-integration.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/central-s3-store/kafka-to-s3-integration.yaml
@@ -6,15 +6,15 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  configuration:
-    - type: configmap
-      value: kafka-to-s3-config
-    - type: secret
-      value: s3-anomaly
+  traits:
+    mount:
+      configs:
+        - configmap:kafka-to-s3-config
+        - secret:s3-anomaly
   profile: OpenShift
   sources:
     - content: |
-       // dependency=camel:camel-endpointdsl
+        // dependency=camel:camel-endpointdsl
         package com.redhat.manuela.routes;
         import java.io.ByteArrayInputStream;
         import java.util.Iterator;

--- a/charts/datacenter/manuela-data-lake/templates/central-s3-store/s3-anomaly-secret.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/central-s3-store/s3-anomaly-secret.yaml
@@ -44,8 +44,20 @@ spec:
     name: s3-anomaly
     template:
       type: Opaque
-  dataFrom:
-  - extract:
+      engineVersion: v2
+      data:
+        application.properties: |
+          AWS_SECRET_ACCESS_KEY: {{ `{{ .aws_secret_access_key }}` }}
+          AWS_ACCESS_KEY_ID: {{ `{{ .aws_access_key_id }}` }}
+  data:
+  - secretKey: aws_secret_access_key
+    remoteRef:
       key: "pushsecrets/s3-anomaly"
+      property: "AWS_SECRET_ACCESS_KEY"
+
+  - secretKey: aws_access_key_id
+    remoteRef:
+      key: "pushsecrets/s3-anomaly"
+      property: "AWS_ACCESS_KEY_ID"
 {{- end }}
 {{- end }}

--- a/charts/datacenter/manuela-tst/templates/development-s3-store/kafka-to-s3-integration.yaml
+++ b/charts/datacenter/manuela-tst/templates/development-s3-store/kafka-to-s3-integration.yaml
@@ -6,11 +6,11 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  configuration:
-    - type: configmap
-      value: kafka-to-s3-config
-    - type: secret
-      value: s3-anomaly
+  traits:
+    mount:
+      configs:
+        - configmap:kafka-to-s3-config
+        - secret:s3-anomaly
   profile: OpenShift
   sources:
     - content: |

--- a/charts/datacenter/manuela-tst/templates/development-s3-store/s3-anomaly-secret.yaml
+++ b/charts/datacenter/manuela-tst/templates/development-s3-store/s3-anomaly-secret.yaml
@@ -15,9 +15,21 @@ spec:
     name: s3-anomaly
     template:
       type: Opaque
-  dataFrom:
-  - extract:
+      engineVersion: v2
+      data:
+        application.properties: |
+          AWS_SECRET_ACCESS_KEY: {{ `{{ .aws_secret_access_key }}` }}
+          AWS_ACCESS_KEY_ID: {{ `{{ .aws_access_key_id }}` }}
+  data:
+  - secretKey: aws_secret_access_key
+    remoteRef:
       key: "pushsecrets/s3-anomaly"
+      property: "AWS_SECRET_ACCESS_KEY"
+
+  - secretKey: aws_access_key_id
+    remoteRef:
+      key: "pushsecrets/s3-anomaly"
+      property: "AWS_ACCESS_KEY_ID"
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
The newly released camel-k 2.5.0 dropped support for the old
spec.configuration mount points and we need to switch to the mount
traits (https://camel.apache.org/camel-k/2.5.x/traits/mount.html)

This seems to mean that the keys inside a secret need to be under the
`application.properties` umbrella, for some java reason that is
escaping us. Amend the s3-anomaly secret creation so that everything
works.

Co-Authored-By: Akos Eros <aeros@redhat.com>
