### PR TITLE
Add workbench-trusted-ca-bundle

### DIFF
--- a/charts/datacenter/data-science-project/templates/dev-project.yaml
+++ b/charts/datacenter/data-science-project/templates/dev-project.yaml
@@ -1,3 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workbench-trusted-ca-bundle
+  namespace: ml-development
+  labels:
+    config.openshift.io/inject-trusted-cabundle: 'true'
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Create a configmap and label it with the
`config.openshift.io/inject-trusted-cabundle: 'true'` label so we can
use it to reference all the trusted certs in the cluster and inject
those in the notebooks.
