### PR TITLE
Cleanup ambiguous deploymentconfig key from svc and deployment selectors

### DIFF
--- a/charts/datacenter/manuela-tst/templates/line-dashboard/line-dashboard-deployment.yaml
+++ b/charts/datacenter/manuela-tst/templates/line-dashboard/line-dashboard-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: line-dashboard
+    app: line-dashboard
     template: openjdk18-web-basic-s2i
     app.kubernetes.io/part-of: ManuELA
   name: line-dashboard
@@ -11,13 +11,12 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      deploymentconfig: line-dashboard
+      app: line-dashboard
   template:
     metadata:
       creationTimestamp: null
       labels:
         app: line-dashboard
-        deploymentconfig: line-dashboard
       name: line-dashboard
     spec:
       containers:

--- a/charts/datacenter/manuela-tst/templates/line-dashboard/line-dashboard-svc.yaml
+++ b/charts/datacenter/manuela-tst/templates/line-dashboard/line-dashboard-svc.yaml
@@ -12,6 +12,5 @@ spec:
     targetPort: 8080
   selector:
     app: line-dashboard
-    deploymentconfig: line-dashboard
   sessionAffinity: None
   type: ClusterIP

--- a/charts/datacenter/manuela-tst/templates/machine-sensor/machine-sensor-1-deployment.yaml
+++ b/charts/datacenter/manuela-tst/templates/machine-sensor/machine-sensor-1-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: machine-sensor-1
+    app: machine-sensor-1
     template: openjdk18-web-basic-s2i
     app.kubernetes.io/part-of: ManuELA
   name: machine-sensor-1
@@ -12,15 +12,14 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      deploymentConfig: machine-sensor-1
+      app: machine-sensor-1
   template:
     metadata:
       creationTimestamp: null
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/machine-sensor/machine-sensor-1-configmap.yaml") . | sha256sum }}
       labels:
-        application: machine-sensor-1
-        deploymentConfig: machine-sensor-1
+        app: machine-sensor-1
       name: machine-sensor-1
     spec:
       containers:

--- a/charts/datacenter/manuela-tst/templates/machine-sensor/machine-sensor-2-deployment.yaml
+++ b/charts/datacenter/manuela-tst/templates/machine-sensor/machine-sensor-2-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: machine-sensor-2
+    app: machine-sensor-2
     template: openjdk18-web-basic-s2i
     app.kubernetes.io/part-of: ManuELA
   name: machine-sensor-2
@@ -12,15 +12,14 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      deploymentConfig: machine-sensor-2
+      app: machine-sensor-2
   template:
     metadata:
       creationTimestamp: null
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/machine-sensor/machine-sensor-2-configmap.yaml") . | sha256sum }}
       labels:
-        application: machine-sensor-2
-        deploymentConfig: machine-sensor-2
+        app: machine-sensor-2
       name: machine-sensor-2
     spec:
       containers:

--- a/charts/datacenter/manuela-tst/templates/messaging/messaging-deployment.yaml
+++ b/charts/datacenter/manuela-tst/templates/messaging/messaging-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: messaging
+    app: messaging
   name: messaging
 spec:
   replicas: 1
@@ -16,7 +16,6 @@ spec:
     metadata:
       labels:
         app: messaging
-        deploymentconfig: messaging
     spec:
       containers:
       - image: {{ .Values.iot_consumer.image_location }}:{{ .Values.iot_consumer.tag }}

--- a/charts/datacenter/manuela-tst/templates/messaging/messaging-svc.yaml
+++ b/charts/datacenter/manuela-tst/templates/messaging/messaging-svc.yaml
@@ -12,6 +12,5 @@ spec:
     targetPort: 3000
   selector:
     app: messaging
-    deploymentconfig: messaging
   sessionAffinity: None
   type: ClusterIP

--- a/charts/factory/manuela-stormshift/templates/anomaly-detection/anomaly-detection-is.yaml
+++ b/charts/factory/manuela-stormshift/templates/anomaly-detection/anomaly-detection-is.yaml
@@ -2,7 +2,7 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   labels:
-    application: anomaly-detection
+    app: anomaly-detection
   name: anomaly-detection
   namespace: manuela-stormshift-messaging
 spec:

--- a/charts/factory/manuela-stormshift/templates/line-dashboard/line-dashboard-deployment.yaml
+++ b/charts/factory/manuela-stormshift/templates/line-dashboard/line-dashboard-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: line-dashboard
+    app: line-dashboard
     template: openjdk18-web-basic-s2i
     app.kubernetes.io/part-of: ManuELA
   name: line-dashboard
@@ -12,13 +12,12 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      deploymentconfig: line-dashboard
+      app: line-dashboard
   template:
     metadata:
       creationTimestamp: null
       labels:
         app: line-dashboard
-        deploymentconfig: line-dashboard
       name: line-dashboard
     spec:
       containers:

--- a/charts/factory/manuela-stormshift/templates/line-dashboard/line-dashboard-svc.yaml
+++ b/charts/factory/manuela-stormshift/templates/line-dashboard/line-dashboard-svc.yaml
@@ -13,6 +13,5 @@ spec:
     targetPort: 8080
   selector:
     app: line-dashboard
-    deploymentconfig: line-dashboard
   sessionAffinity: None
   type: ClusterIP

--- a/charts/factory/manuela-stormshift/templates/machine-sensor/machine-sensor-1-deployment.yaml
+++ b/charts/factory/manuela-stormshift/templates/machine-sensor/machine-sensor-1-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: machine-sensor-1
+    app: machine-sensor-1
     template: openjdk18-web-basic-s2i
     app.kubernetes.io/part-of: ManuELA
   name: machine-sensor-1
@@ -12,15 +12,14 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      deploymentConfig: machine-sensor-1
+      app: machine-sensor-1
   template:
     metadata:
       creationTimestamp: null
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/machine-sensor/machine-sensor-1-configmap.yaml") . | sha256sum }}
       labels:
-        application: machine-sensor-1
-        deploymentConfig: machine-sensor-1
+        app: machine-sensor-1
       name: machine-sensor-1
     spec:
       containers:

--- a/charts/factory/manuela-stormshift/templates/machine-sensor/machine-sensor-2-deployment.yaml
+++ b/charts/factory/manuela-stormshift/templates/machine-sensor/machine-sensor-2-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: machine-sensor-2
+    app: machine-sensor-2
     template: openjdk18-web-basic-s2i
     app.kubernetes.io/part-of: ManuELA
   name: machine-sensor-2
@@ -12,15 +12,14 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      deploymentConfig: machine-sensor-2
+      app: machine-sensor-2
   template:
     metadata:
       creationTimestamp: null
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/machine-sensor/machine-sensor-2-configmap.yaml") . | sha256sum }}
       labels:
-        application: machine-sensor-2
-        deploymentConfig: machine-sensor-2
+        app: machine-sensor-2
       name: machine-sensor-2
     spec:
       containers:

--- a/charts/factory/manuela-stormshift/templates/messaging/messaging-deployment.yaml
+++ b/charts/factory/manuela-stormshift/templates/messaging/messaging-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: messaging
+    app: messaging
   name: messaging
   namespace: manuela-stormshift-messaging
 spec:
@@ -17,7 +17,6 @@ spec:
     metadata:
       labels:
         app: messaging
-        deploymentconfig: messaging
     spec:
       containers:
       - image: {{ .Values.iot_consumer.image_location }}:{{ .Values.iot_consumer.tag }}

--- a/charts/factory/manuela-stormshift/templates/messaging/messaging-svc.yaml
+++ b/charts/factory/manuela-stormshift/templates/messaging/messaging-svc.yaml
@@ -13,6 +13,5 @@ spec:
     targetPort: 3000
   selector:
     app: messaging
-    deploymentconfig: messaging
   sessionAffinity: None
   type: ClusterIP

--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -122,10 +122,6 @@ clusterGroup:
         kind: ImageStream
         jsonPointers:
         - /spec/tags
-      - group: apps.openshift.io
-        kind: DeploymentConfig
-        jsonPointers:
-        - /spec/template/spec/containers/0/image
 
     storage:
       name: storage
@@ -152,10 +148,6 @@ clusterGroup:
         kind: ImageStream
         jsonPointers:
         - /spec/tags
-      - group: apps.openshift.io
-        kind: DeploymentConfig
-        jsonPointers:
-        - /spec/template/spec/containers/0/image
 
     data-science-project:
       name: data-science-project
@@ -175,10 +167,6 @@ clusterGroup:
         kind: ImageStream
         jsonPointers:
         - /spec/tags
-      - group: apps.openshift.io
-        kind: DeploymentConfig
-        jsonPointers:
-        - /spec/template/spec/containers/0/image
 
     test:
       name: manuela-test


### PR DESCRIPTION
Cleanup old, deprecated selectors from SVC, deployment resources.

Use label "app" on deployments, to be consistent how it is on svc, route.