### PR TITLE
More cleanups

### DIFF
--- a/charts/datacenter/data-science-cluster/templates/serving-runtimes.yaml
+++ b/charts/datacenter/data-science-cluster/templates/serving-runtimes.yaml
@@ -33,7 +33,7 @@ objects:
       grpcDataEndpoint: 'port:8001'
       containers:
         - name: mlserver
-          image: 'seldonio/mlserver:1.3.5'
+          image: 'docker.io/seldonio/mlserver:1.3.5'
           env:
             - name: MLSERVER_MODELS_DIR
               value: /models/_mlserver_models/

--- a/charts/datacenter/data-science-project/templates/modelmesh/serving-runtime.yaml
+++ b/charts/datacenter/data-science-project/templates/modelmesh/serving-runtime.yaml
@@ -44,7 +44,7 @@ spec:
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
           value: '-1'
-      image: 'seldonio/mlserver:1.3.5'
+      image: 'docker.io/seldonio/mlserver:1.3.5'
       name: mlserver
       resources:
         limits:

--- a/charts/datacenter/manuela-data-lake/templates/central-s3-store/kafka-to-s3-cm.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/central-s3-store/kafka-to-s3-cm.yaml
@@ -11,7 +11,7 @@ data:
 
     s3.region=none
     s3.bucket.name={{ .Values.kafka.s3.bucket }}
-    s3.message.aggregation.count={{ .Values.global.s3.bucket.message.aggregation.count }}
+    s3.message.aggregation.count={{ .Values.kafka.s3.message.aggregation.count }}
     s3.custom.endpoint.enabled=true
     # Convert this directory into a helm chart and use templating to set this
     s3.custom.endpoint.url={{ .Values.kafka.s3.endpointurl }}

--- a/charts/datacenter/manuela-data-lake/values.yaml
+++ b/charts/datacenter/manuela-data-lake/values.yaml
@@ -3,12 +3,6 @@ global:
     clustername: datacenter-XXXXX
     domain: BASEDOMAIN
 
-  s3:
-    bucket:
-      message:
-        aggregation:
-          count: 50
-
 clusterGroup:
   name: datacenter
   isHubCluster: true
@@ -34,6 +28,9 @@ kafka:
   s3:
     bucket: anomaly-detection
     endpointurl: http://s3.openshift-storage.svc
+    message:
+      aggregation:
+        count: 50
   broker:
     uri: "prod-kafka-cluster-kafka-bootstrap.manuela-data-lake.svc:9092"
     topic:

--- a/charts/datacenter/manuela-tst/templates/anomaly-detection/serving-runtime.yaml
+++ b/charts/datacenter/manuela-tst/templates/anomaly-detection/serving-runtime.yaml
@@ -44,7 +44,7 @@ spec:
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
           value: '-1'
-      image: 'seldonio/mlserver:1.3.5'
+      image: 'docker.io/seldonio/mlserver:1.3.5'
       name: mlserver
       resources:
         limits:

--- a/charts/datacenter/manuela-tst/templates/development-s3-store/kafka-to-s3-cm.yaml
+++ b/charts/datacenter/manuela-tst/templates/development-s3-store/kafka-to-s3-cm.yaml
@@ -12,7 +12,7 @@ data:
     local.cluster.name={{ .Values.global.localClusterDomain }}
     s3.region=none
     s3.bucket.name={{ .Values.kafka.s3.bucket }}
-    s3.message.aggregation.count={{ .Values.global.s3.bucket.message.aggregation.count }}
+    s3.message.aggregation.count={{ .Values.kafka.s3.message.aggregation.count }}
     s3.custom.endpoint.enabled=true
     # Convert this directory into a helm chart and use templating to set this
     s3.custom.endpoint.url={{ .Values.kafka.s3.endpointurl }}

--- a/charts/datacenter/manuela-tst/templates/development-s3-store/s3-anomaly-secret.yaml
+++ b/charts/datacenter/manuela-tst/templates/development-s3-store/s3-anomaly-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.clusterGroup.isHubCluster }}
+{{- if and .Values.clusterGroup .Values.clusterGroup.isHubCluster }}
 {{- if .Values.global.originURL }}
 ---
 apiVersion: "external-secrets.io/v1beta1"

--- a/charts/datacenter/manuela-tst/values.yaml
+++ b/charts/datacenter/manuela-tst/values.yaml
@@ -8,12 +8,6 @@ global:
     hostname: quay.io
     type: quay
 
-  s3:
-    bucket:
-      message:
-        aggregation:
-          count: 50
-
 secretStore:
   name: vault-backend
   kind: ClusterSecretStore
@@ -42,6 +36,10 @@ kafka:
   s3:
     bucket: anomaly-detection
     endpointurl: http://s3.openshift-storage.svc
+    message:
+      aggregation:
+        count: 50
+
   broker:
     uri: "dev-kafka-cluster-kafka-bootstrap.manuela-tst-all.svc:9092"
     topic:

--- a/charts/factory/manuela-stormshift/templates/anomaly-detection/serving-runtime.yaml
+++ b/charts/factory/manuela-stormshift/templates/anomaly-detection/serving-runtime.yaml
@@ -45,7 +45,7 @@ spec:
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
           value: '-1'
-      image: 'seldonio/mlserver:1.3.5'
+      image: 'docker.io/seldonio/mlserver:1.3.5'
       name: mlserver
       resources:
         limits:

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -25,9 +25,3 @@ global:
     email: SOMEWHERE@EXAMPLE.COM
     # Branch used for the manuela-dev repository
     dev_revision: main
-
-  s3:
-    bucket:
-      message:
-        aggregation:
-          count: 50


### PR DESCRIPTION
- **Stop using global for s3 bucket aggregation variable**
- **Use FQDN when pulling the mlserver image**
