### PR TITLE
Drop unused namespaces

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -24,9 +24,6 @@ clusterGroup:
   - redhat-ods-operator:
       operatorGroup: true
       targetNamespaces:
-  - edge-workspace
-  - edge-test-all
-  - edge-ci
   - ml-development:
       labels:
         modelmesh-enabled: 'true'


### PR DESCRIPTION
They are unused:
❯ for i in edge-workspace edge-test-all edge-ci; do grep -ir $i |wc -l; done
0
0
0
