### PR TITLE
Drop cluster admin from pipeline account

### DIFF
--- a/charts/datacenter/pipelines/templates/pipeline-serviceaccount-rb.yaml
+++ b/charts/datacenter/pipelines/templates/pipeline-serviceaccount-rb.yaml
@@ -1,16 +1,3 @@
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: admin
-  namespace: manuela-tst-all
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-  - kind: ServiceAccount
-    name: pipeline
-    namespace: manuela-ci
 {{- if eq .Values.global.imageregistry.type "openshift" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
It is not needed. Tested with seed pipeline and one build-and-test and
both were green.
