### PR TITLE
Force a refresh when calling argocd sync and wait

### DIFF
--- a/charts/datacenter/pipelines/templates/tasks/argocd-sync-and-wait.yaml
+++ b/charts/datacenter/pipelines/templates/tasks/argocd-sync-and-wait.yaml
@@ -30,5 +30,6 @@ spec:
         - if [ -z $ARGOCD_AUTH_TOKEN ]; then
             yes | argocd login $(params.argocd-server) --grpc-web $(params.flags) --username=$(cat $(workspaces.argocd-env-secret.path)/ARGOCD_USERNAME) --password=$(cat $(workspaces.argocd-env-secret.path)/ARGOCD_PASSWORD);
           fi;
+        - argocd app get --refresh $(params.application.name);
         - argocd app sync $(params.application-name) --revision $(params.revision) $(params.flags);
         - argocd app wait $(params.application-name) --health $(params.flags);


### PR DESCRIPTION
This helps the demo situation where you change something in gitea
for manuela-dev and trigger the pipelines, because you will instantly
see the change rolling out.
