### PR TITLE
Fix some issues with the sensor test

### DIFF
--- a/tests/interop/test_toggle_machine_sensor.py
+++ b/tests/interop/test_toggle_machine_sensor.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 import os
 import re
@@ -37,8 +38,8 @@ def get_gitea_info():
         err_msg = "The gitea-admin-secret was not found in ns vp-gitea"
         logger.error(f"FAIL: {err_msg}")
         assert False, err_msg
-    username = gitea_secret.instance.data.username
-    password = gitea_secret.instance.data.password
+    username = base64.b64decode(gitea_secret.instance.data.username).decode("utf-8")
+    password = base64.b64decode(gitea_secret.instance.data.password).decode("utf-8")
 
     try:
         gitea_route_obj = Route.get(
@@ -128,7 +129,17 @@ def test_toggle_machine_sensor(openshift_dyn_client):
     else:
         cur_dir = os.getcwd()
 
+    # We remove the 'gitea-qe' remote in case it already exists
     subprocess.run(
+        [
+            "git",
+            "remote",
+            "remove",
+            "gitea-qe",
+        ],
+        cwd=cur_dir,
+    )
+    res = subprocess.run(
         [
             "git",
             "-c",
@@ -141,6 +152,11 @@ def test_toggle_machine_sensor(openshift_dyn_client):
         ],
         cwd=cur_dir,
     )
+    if res.returncode != 0:
+        err_msg = f"Could not fetch remote from gitea_url: {gitea_url}"
+        logger.error(f"FAIL: {err_msg}")
+        assert False, err_msg
+
     subprocess.run(["git", "add", machine_sensor_file], cwd=cur_dir)
     subprocess.run(
         ["git", "commit", "-m", "Toggling SENSOR_TEMPERATURE_ENABLED"],
@@ -152,6 +168,11 @@ def test_toggle_machine_sensor(openshift_dyn_client):
         capture_output=True,
         text=True,
     )
+    if push.returncode != 0:
+        err_msg = f"Could not push to gitea_url: {gitea_url}"
+        logger.error(f"FAIL: {err_msg} - {push.stdout} - {push.stderr}")
+        assert False, err_msg
+
     logger.info(push.stdout)
     logger.info(push.stderr)
 


### PR DESCRIPTION
1. Make sure we use the base64-decoded strings from the gitea_admin
   secret (for both username and password)

2. If we're unable to fetch from the gitea remote, error out and explain
   why

3. Also error out properly when git push fails

4. Also remove the gitea-qe remote everytime to make this more
   idempotent

With these changes I was able to get it passing again:

    test_toggle_machine_sensor.py::test_toggle_machine_sensor PASSED [100%]
