### PR TITLE
Add storage overrides for different clouds

### DIFF
--- a/values-AWS.yaml
+++ b/values-AWS.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: gp3-csi

--- a/values-Azure.yaml
+++ b/values-Azure.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: managed-csi

--- a/values-GCP.yaml
+++ b/values-GCP.yaml
@@ -1,0 +1,3 @@
+global:
+  datacenter:
+    storageClassName: standard-csi


### PR DESCRIPTION
The helm variable `global.datacenter.storageClassName` is used by the
ODF chart to pick the storage class for its storageclass.
It defaults to `gp3-csi` which only exists in AWS.

Let's add three overrides for the major clouds, picking the right
storageclass for that cloud. Also add one for the AWS one just to make
things more explicit.

Reported-By: Mark Labonte <mlabonte@redhat.com>
