### PR TITLE
Serialize tasks when used in the seed pipeline

### DIFF
--- a/charts/datacenter/pipelines/templates/_helpers.tpl
+++ b/charts/datacenter/pipelines/templates/_helpers.tpl
@@ -52,6 +52,10 @@ ie-registry
   runAfter:
 {{- if (eq .component.component_name "iot-frontend") }}
   - build-base-image
+{{- else if and (eq .seed_prod "true") (eq .component.component_name "iot-consumer") }}
+  - modify-ops-prod-iot-component-iot-frontend
+{{- else if and (eq .seed_prod "true") (eq .component.component_name "iot-software-sensor") }}
+  - modify-ops-prod-iot-component-iot-consumer
 {{- else }}
   - git-clone-ops
   - git-clone-dev


### PR DESCRIPTION
mlabonte saw some racey behaviour in the `make seed` pipeline.
It seems we are exposed to some races due to the parallelization
of some tasks and the use of yq on files.

For the time being let's go back at running things serially.
We can investigate later on how to speed things up a bit more if needed.

Reported-By: Mark Labonte <mlabonte@redhat.com>
Co-Authored-By: Akos Eros <aeros@redhat.com>
