### PR TITLE
Switch to docker.io/seldonio/mlserver:1.3.5-sklearn

### DIFF
--- a/charts/datacenter/data-science-cluster/templates/serving-runtimes.yaml
+++ b/charts/datacenter/data-science-cluster/templates/serving-runtimes.yaml
@@ -33,7 +33,7 @@ objects:
       grpcDataEndpoint: 'port:8001'
       containers:
         - name: mlserver
-          image: 'docker.io/seldonio/mlserver:1.3.5'
+          image: 'docker.io/seldonio/mlserver:1.3.5-sklearn'
           env:
             - name: MLSERVER_MODELS_DIR
               value: /models/_mlserver_models/

--- a/charts/datacenter/data-science-project/templates/modelmesh/serving-runtime.yaml
+++ b/charts/datacenter/data-science-project/templates/modelmesh/serving-runtime.yaml
@@ -44,7 +44,7 @@ spec:
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
           value: '-1'
-      image: 'docker.io/seldonio/mlserver:1.3.5'
+      image: 'docker.io/seldonio/mlserver:1.3.5-sklearn'
       name: mlserver
       resources:
         limits:

--- a/charts/datacenter/manuela-tst/templates/anomaly-detection/serving-runtime.yaml
+++ b/charts/datacenter/manuela-tst/templates/anomaly-detection/serving-runtime.yaml
@@ -44,7 +44,7 @@ spec:
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
           value: '-1'
-      image: 'docker.io/seldonio/mlserver:1.3.5'
+      image: 'docker.io/seldonio/mlserver:1.3.5-sklearn'
       name: mlserver
       resources:
         limits:

--- a/charts/factory/manuela-stormshift/templates/anomaly-detection/serving-runtime.yaml
+++ b/charts/factory/manuela-stormshift/templates/anomaly-detection/serving-runtime.yaml
@@ -45,7 +45,7 @@ spec:
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
           value: '-1'
-      image: 'docker.io/seldonio/mlserver:1.3.5'
+      image: 'docker.io/seldonio/mlserver:1.3.5-sklearn'
       name: mlserver
       resources:
         limits:


### PR DESCRIPTION
This image is almost a 1/4th of the 1.3.5 bigger image 0.93GB vs 3.74GB
and since we use the `sklearn` model this is okay to do and alleviates
some of the pain we see due to the download size.

Tested this and the line-dashboard kept working correctly on both hub
and factory.
