### PR TITLE
Fix logging edge test

### DIFF
--- a/tests/interop/test_check_logging_edge.py
+++ b/tests/interop/test_check_logging_edge.py
@@ -49,7 +49,7 @@ def test_check_logging_edge():
         [
             oc,
             "exec",
-            "factory-kafka-cluster-kafka-0",
+            "factory-cluster-factory-0",
             "-c",
             "kafka",
             "-n",
@@ -58,7 +58,7 @@ def test_check_logging_edge():
             "bin/kafka-topics.sh",
             "--list",
             "--bootstrap-server",
-            "factory-kafka-cluster-kafka-bootstrap:9092",
+            "factory-cluster-kafka-bootstrap:9092",
         ],
         capture_output=True,
     )


### PR DESCRIPTION
After switching kafka to use kRaft a couple of names changed and so this
test will fail. Fix it to use the correct names. Tested on the spoke with:

    ❯ oc exec factory-cluster-factory-0 -c kafka -n manuela-stormshift-messaging -- bin/kafka-topics.sh --list --bootstrap-server factory-cluster-kafka-bootstrap:9092
    manuela-factory.iot-sensor-sw-temperature
    manuela-factory.iot-sensor-sw-vibration
    mm2-offset-syncs.production-kafka-cluster.internal
