### PR TITLE
Switch to ODF 0.2.* chart

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -121,7 +121,7 @@ clusterGroup:
       namespace: openshift-storage
       project: datacenter
       chart: openshift-data-foundations
-      chartVersion: 0.1.*
+      chartVersion: 0.2.*
 
     data-science-cluster:
       name: data-science-cluster


### PR DESCRIPTION
This allows us to install IE (and ODF) out of the box on nodes all
belonging to the same AZ. (Which is the case for most RHDP clusters)
