### PR TITLE
Export TRUSTED_CA_BUNDLE_PATH in the notebooks and bind mount the certs in the main notebook

### DIFF
--- a/charts/datacenter/data-science-project/templates/dev-project.yaml
+++ b/charts/datacenter/data-science-project/templates/dev-project.yaml
@@ -200,6 +200,8 @@ spec:
               value: /etc/pki/tls/custom-certs/ca-bundle.crt
             - name: PIP_CERT
               value: /etc/pki/tls/custom-certs/ca-bundle.crt
+            - name: TRUSTED_CA_BUNDLE_PATH
+              value: /etc/pki/tls/custom-certs/ca-bundle.crt
             - name: REQUESTS_CA_BUNDLE
               value: /etc/pki/tls/custom-certs/ca-bundle.crt
           ports:
@@ -214,6 +216,10 @@ spec:
               name: elyra-dsp-details
             - mountPath: /dev/shm
               name: shm
+            - mountPath: /etc/pki/tls/custom-certs/ca-bundle.crt
+              name: ca-bundles
+              readOnly: true
+              subPath: ca-bundle.crt
           image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/industrial-edge:industrial-edge-v0.1.0
           workingDir: /opt/app-root/src
         - resources:
@@ -459,6 +465,8 @@ spec:
             - name: GIT_SSL_CAINFO
               value: /etc/pki/tls/custom-certs/ca-bundle.crt
             - name: PIP_CERT
+              value: /etc/pki/tls/custom-certs/ca-bundle.crt
+            - name: TRUSTED_CA_BUNDLE_PATH
               value: /etc/pki/tls/custom-certs/ca-bundle.crt
             - name: REQUESTS_CA_BUNDLE
               value: /etc/pki/tls/custom-certs/ca-bundle.crt


### PR DESCRIPTION
According to https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html?highlight=ssl
seeting TRUSTED_CA_BUNDLE_PATH is how you set the CA pem file for elyra pipelines.

But in order to do that we also need to bind mount the tls mount point
in the main jupyter so that we can actually reference that CA bundle
which contains both the official CAs and the internal cluster ones.
