### PR TITLE
Pin camel-k to v2.5.1

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -54,6 +54,8 @@ clusterGroup:
       - manuela-data-lake
       - manuela-tst-all
       channel: stable-v2
+      csv: camel-k-operator.v2.5.1
+      installPlanApproval: Manual
       source: community-operators
       sourceNamespace: openshift-marketplace
 

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -13,6 +13,7 @@ global:
     useCSV: False
     syncPolicy: Automatic
     installPlanApproval: Automatic
+    autoApproveManualInstallPlans: true
 
   imageregistry:
     # account: PLAINTEXT


### PR DESCRIPTION
We pin the camel-k version to v2.5.1 and enable the automatic approval
via cronjob so the user does not need to do anything.

Reason for this is that we've observed a bunch of failures with v2.6.0
which will need proper investigation and potential bug filing.

For example:

    message: 'successfully installed Kamelet catalog version 4.8.3: success 246 Kamelets, failed 1 Kamelets. Check operator log to discover more about the failure'

and:

    {"level":"info","ts":"2025-02-26T19:38:29Z","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"integrationkit-controller","object":{"name":"kit-cuvm166inkrc73dat190","namespace":"manuela-data-lake"},"namespace":"manuela-data-lake","name":"kit-cuvm166inkrc73dat190","reconcileID":"50982d99-7168-441a-a455-980737f71555"}
    panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x20f62bd]

With v2.5.1 we get the integrations running again.
