### PR TITLE
Upgrade super-linter to v8.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
     schedule:
       interval: "weekly"
 
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,6 +1,7 @@
 ---
 name: Super linter
 
+permissions: read-all # zizmor: ignore[excessive-permissions]
 on: [push, pull_request]
 
 jobs:
@@ -12,8 +13,9 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
@@ -21,7 +23,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7
+        uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -41,5 +43,12 @@ jobs:
           VALIDATE_TEKTON: false
           VALIDATE_YAML: false
           VALIDATE_YAML_PRETTIER: false
-          # VALIDATE_MARKDOWN: false
-          # VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_SPELL_CODESPELL: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_PYINK: false
+          VALIDATE_PYTHON_RUFF_FORMAT: false
+          VALIDATE_TRIVY: false
+          FILTER_REGEX_EXCLUDE: .*/common/.*

--- a/.github/workflows/sync-rhdp-branch.yml
+++ b/.github/workflows/sync-rhdp-branch.yml
@@ -13,16 +13,21 @@ jobs:
       github.repository_owner == 'validatedpatterns'
     runs-on: ubuntu-latest
     name: Git Sync branch
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: Opening pull request
         id: pull
-        uses: mbaldessari/git-sync-branch@v0.2.0
+        uses: mbaldessari/git-sync-branch@dd2adf0ca96e52c64716d83cabe85fac33201e12 # v0.2.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FROM_BRANCH: "main"

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -1,6 +1,6 @@
 # This job requires a secret called DOCS_TOKEN which should be a PAT token
 # that has the permissions described in:
-# validatedpatterns/docs/.github/workflows/metadata-docs.yml@main
+# validatedpatterns/docs/.github/workflows/metadata-docs.yml@main # zizmor: ignore[unpinned-uses]
 ---
 name: Update docs pattern metadata
 
@@ -14,12 +14,12 @@ on:
 
 jobs:
   update-metadata:
-    uses: validatedpatterns/docs/.github/workflows/metadata-docs.yml@main
+    uses: validatedpatterns/docs/.github/workflows/metadata-docs.yml@main # zizmor: ignore[unpinned-uses]
     permissions: # Workflow-level permissions
       contents: read  # Required for "read-all"
       packages: write # Allows writing to packages
       id-token: write # Allows creating OpenID Connect (OIDC) tokens
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     # For testing you can point to a different branch in the docs repository
     # with:
     #  DOCS_BRANCH: "main"

--- a/charts/datacenter/pipelines/images/bumpversiontask/README.md
+++ b/charts/datacenter/pipelines/images/bumpversiontask/README.md
@@ -1,4 +1,4 @@
 # bumpversiontask
 
 Create a container image that can be used as Tekton task to bump a version using bump2version.
-Image is build using quay, you can find the consumable image [here](https://quay.io/repository/hybridcloudpatterns/bumpversiontask?tab=tags)
+Image is build using quay, you can find the consumable image [in this quay repository](https://quay.io/repository/hybridcloudpatterns/bumpversiontask?tab=tags)


### PR DESCRIPTION
- Pin super-linter to v8.5.0 (SHA 61abc07d)
- Pin all GitHub Actions to SHA references
- Add persist-credentials: false to checkout steps
- Add permissions: read-all to workflow files
- Add dependabot cooldown and grouping configuration
- Disable new v8 linters not applicable to this repo
- Add FILTER_REGEX_EXCLUDE for nested .github directories
- Add zizmor ignore comments for reusable workflow refs
- Update markdownlint config for new rules
- Migrate ansible-lint-action to ansible/ansible-lint
